### PR TITLE
Add fetchWithTimeout 

### DIFF
--- a/src-ui/lib/openLibrary.spec.ts
+++ b/src-ui/lib/openLibrary.spec.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { getByISBN } from './openLibrary'
 
 describe('book', () => {
   describe('#getByISBN', () => {
+    const isbn = '9780441004225'
     it('should be able to retrieve The Stainless Steel Rat (9780441004225)', async () => {
       9780425038192
-      const isbn = '9780441004225'
       const book = await getByISBN(isbn)
       const expected = {
         authors: ['Harry Harrison'],
@@ -26,6 +26,25 @@ describe('book', () => {
       }
       expect(book).toEqual(expected)
     })
+    it('should throw a timeout error when Open Library is down and request times out', async () => {
+      global.fetch = vi.fn(
+        (_: Request, { signal }: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            // Simulate the request being aborted
+            signal?.addEventListener('abort', () => {
+              reject(new DOMException('Aborted', 'AbortError'))
+            })
+          })
+      )
+      await getByISBN(isbn)
+        .then(() => {
+          throw new Error('Test failed: Expected a timeout error')
+        })
+        .catch((error) => {
+          expect(error.message).toBe('Fetch request timed out')
+        })
+    })
+
     it.skip("should be able to retrieve The Stainless Steel Rat's Revenge (9781857984996)", async () => {})
     it.skip("should be able to retrieve another edition of The Stainless Steel Rat's Revenge (9780575115408)", async () => {})
     it.skip('should be able to retrieve The Dragons of Heaven (9780857664334)', async () => {})


### PR DESCRIPTION
This PR is my first pass at adding a new method, fetchWithTimeout, that aborts the fetch after a certain amount of time. This method is passed to createClient in openLibrary, and is used whenever we do a GET. It also adds a test for it!