### PR TITLE
(1) Fix sqlite_proxy bugs.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5867,7 +5867,7 @@ snapshots:
       '@types/node': 22.7.4
     optional: true
 
-  '@typescript-eslint/eslint-plugin@2.34.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(typescript@3.9.10)':
+  '@typescript-eslint/eslint-plugin@2.34.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@3.9.10))(eslint@9.11.1)(typescript@3.9.10)':
     dependencies:
       '@typescript-eslint/experimental-utils': 2.34.0(eslint@9.11.1)(typescript@3.9.10)
       '@typescript-eslint/parser': 2.34.0(eslint@9.11.1)(typescript@3.9.10)
@@ -7134,10 +7134,10 @@ snapshots:
 
   eslint-config-ts@4.0.1(eslint@9.11.1):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(typescript@3.9.10)
+      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@3.9.10))(eslint@9.11.1)(typescript@3.9.10)
       '@typescript-eslint/parser': 2.34.0(eslint@9.11.1)(typescript@3.9.10)
       eslint: 9.11.1
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@3.9.10))(eslint@9.11.1)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@9.11.1)
       eslint-plugin-node: 10.0.0(eslint@9.11.1)
       eslint-plugin-react: 7.36.1(eslint@9.11.1)
@@ -7156,7 +7156,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.11.1(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@9.11.1):
+  eslint-module-utils@2.11.1(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@3.9.10))(eslint-import-resolver-node@0.3.9)(eslint@9.11.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7172,7 +7172,7 @@ snapshots:
       eslint-utils: 1.4.3
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.30.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1):
+  eslint-plugin-import@2.30.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@3.9.10))(eslint@9.11.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -7183,7 +7183,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.11.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.11.1(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@9.11.1)
+      eslint-module-utils: 2.11.1(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@3.9.10))(eslint-import-resolver-node@0.3.9)(eslint@9.11.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5867,7 +5867,7 @@ snapshots:
       '@types/node': 22.7.4
     optional: true
 
-  '@typescript-eslint/eslint-plugin@2.34.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@3.9.10))(eslint@9.11.1)(typescript@3.9.10)':
+  '@typescript-eslint/eslint-plugin@2.34.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(typescript@3.9.10)':
     dependencies:
       '@typescript-eslint/experimental-utils': 2.34.0(eslint@9.11.1)(typescript@3.9.10)
       '@typescript-eslint/parser': 2.34.0(eslint@9.11.1)(typescript@3.9.10)
@@ -7134,10 +7134,10 @@ snapshots:
 
   eslint-config-ts@4.0.1(eslint@9.11.1):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@3.9.10))(eslint@9.11.1)(typescript@3.9.10)
+      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(typescript@3.9.10)
       '@typescript-eslint/parser': 2.34.0(eslint@9.11.1)(typescript@3.9.10)
       eslint: 9.11.1
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@3.9.10))(eslint@9.11.1)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@9.11.1)
       eslint-plugin-node: 10.0.0(eslint@9.11.1)
       eslint-plugin-react: 7.36.1(eslint@9.11.1)
@@ -7156,7 +7156,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.11.1(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@3.9.10))(eslint-import-resolver-node@0.3.9)(eslint@9.11.1):
+  eslint-module-utils@2.11.1(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@9.11.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7172,7 +7172,7 @@ snapshots:
       eslint-utils: 1.4.3
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.30.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@3.9.10))(eslint@9.11.1):
+  eslint-plugin-import@2.30.0(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -7183,7 +7183,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.11.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.11.1(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@3.9.10))(eslint-import-resolver-node@0.3.9)(eslint@9.11.1)
+      eslint-module-utils: 2.11.1(@typescript-eslint/parser@2.34.0(eslint@9.11.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@9.11.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2802,6 +2802,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
+ "indexmap 2.6.0",
  "itoa 1.0.11",
  "memchr",
  "ryu",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.81"
 tauri-build = { version = "2.0.0-rc", features = [] }
 
 [dependencies]
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "2.0.2", features = ["test"] }
 futures-core = "0.3.30"

--- a/src-tauri/src/plugins/sqlite_proxy/json_param.rs
+++ b/src-tauri/src/plugins/sqlite_proxy/json_param.rs
@@ -1,0 +1,29 @@
+use rusqlite::types::ToSql;
+use serde_json::Value;
+
+#[derive(Clone, Debug)]
+pub(super) struct JsonParam(Value);
+
+/// A wrapper for `serde_json::Value` to facilitate usage as parameter values
+/// for non-JSON fields.
+///
+/// This is necessary because the default `to_sql` implementation encodes JSON
+/// directly, which leaves extra `"` around text values. See: https://github.com/rusqlite/rusqlite/issues/1312
+impl From<Value> for JsonParam {
+    fn from(value: Value) -> Self {
+        JsonParam(value)
+    }
+}
+
+impl ToSql for JsonParam {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        match &self.0 {
+            Value::String(s) => s.as_str().to_sql(), // direct conversion instead of producing "str".
+            _ => self.0.to_sql(), // original to_sql already handles other values correctly.
+        }
+    }
+}
+
+pub(super) fn into_json_params(params: Vec<Value>) -> Vec<JsonParam> {
+    params.into_iter().map(JsonParam::from).collect()
+}

--- a/src-tauri/src/plugins/sqlite_proxy/lib.rs
+++ b/src-tauri/src/plugins/sqlite_proxy/lib.rs
@@ -168,23 +168,32 @@ mod test {
           result
         );
         // Keys must respect query order
-        assert_eq!(result[0].keys().map(|k| k.as_str()).collect::<Vec<_>>(), vec!["title", "id", "authors"]);
-        assert_eq!(result[1].keys().map(|k| k.as_str()).collect::<Vec<_>>(), vec!["title", "id", "authors"]);
+        assert_eq!(
+            result[0].keys().map(|k| k.as_str()).collect::<Vec<_>>(),
+            vec!["title", "id", "authors"]
+        );
+        assert_eq!(
+            result[1].keys().map(|k| k.as_str()).collect::<Vec<_>>(),
+            vec!["title", "id", "authors"]
+        );
 
         // #`query_row` -> {column_name: value}
         let result = query_row(
-                &connection,
-                "SELECT * FROM books WHERE id = 2".to_string(),
-                None,
-            )
-            .unwrap();
+            &connection,
+            "SELECT * FROM books WHERE id = 2".to_string(),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             json!({"id": 2, "title": "The Princess and the Grilled Cheese Sandwich", "authors": "[\"Deya Muniz\"]"}).as_object().unwrap().clone(),
             result
         );
 
         // keys maintain order of table definition by default
-        assert_eq!(result.keys().map(|k| k.as_str()).collect::<Vec<_>>(), vec!["id", "title", "authors"]);
+        assert_eq!(
+            result.keys().map(|k| k.as_str()).collect::<Vec<_>>(),
+            vec!["id", "title", "authors"]
+        );
         Ok(())
     }
 

--- a/src-tauri/src/plugins/sqlite_proxy/mod.rs
+++ b/src-tauri/src/plugins/sqlite_proxy/mod.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod error;
+mod json_param;
 mod lib;
 use std::sync::Mutex;
 


### PR DESCRIPTION
This is the first PR that breaks down https://github.com/Candid-Engineering/books-db/pull/21 into digestible chunks. We are mainly fixing two bugs in the sqlite_proxy library we developed:

1. Order of columns - existing behavior sorted them ~alphabetically; and used `Map` instead of `OrderedMap`. There is a feature in `serde_json` to fix this behavior by default when serializing JSON.
2. Remove extraneous wrapping of every parameter in `"`. I'm doing this by introducing a new type that serializes into sql parameters as I expect.

Also added tests for the behavior to avoid future regressions.