### PR TITLE
Fix several issues with the migrations rewrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test:rust": "pnpm rust:test",
     "test:e2e": "pnpm e2e",
     "dev": "pnpm tauri dev",
+    "db:drop": "cargo xtask db:drop",
+    "gen:migration": "cargo xtask gen:migration",
     "build": "pnpm tauri build",
     "gen:schema": "cargo xtask gen:schema",
     "js:format": "prettier --write .",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,9 +3,6 @@
 
 use std::env;
 
-use migrations::lib::get_migrations;
-
-pub mod migrations;
 pub mod plugins;
 
 fn main() {
@@ -19,10 +16,7 @@ fn main() {
         // TODO(rkofman): the name of the DB should be updated based on `.env` variables.
         // `books.db` for prod, `books-dev.db` for dev, and probably `:memory:` for test.
         // Also: consider moving this to the config file (assuming per-env configs).
-        .plugin(plugins::sqlite_proxy::init(
-            "books-dev.db",
-            &get_migrations(),
-        ))
+        .plugin(plugins::sqlite_proxy::init("books-dev.db"))
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/plugins/sqlite_proxy/mod.rs
+++ b/src-tauri/src/plugins/sqlite_proxy/mod.rs
@@ -16,10 +16,7 @@ use tauri::Manager;
 use tauri::Runtime;
 use tauri::Wry;
 
-pub fn init(
-    filename: impl Into<String> + Send + 'static,
-    migrations: &[Migration],
-) -> TauriPlugin<Wry> {
+pub fn init(filename: impl Into<String> + Send + 'static) -> TauriPlugin<Wry> {
     // typescript export builder
     let specta_builder = tauri_specta::Builder::<tauri::Wry>::new()
         .commands(tauri_specta::collect_commands![query, query_row, execute])
@@ -34,12 +31,10 @@ pub fn init(
         )
         .expect("Failed to export typescript bindings");
 
-    let migrations = migrations.to_vec(); // clones migrations to extend ownership.
-
     Builder::new("sqlite-proxy")
         .setup(move |app, api| {
             specta_builder.mount_events(app);
-            setup(app, api, &filename.into(), &migrations)
+            setup(app, api, &filename.into())
         })
         .invoke_handler(tauri::generate_handler![query, query_row, execute])
         .build()
@@ -49,14 +44,12 @@ fn setup<R: Runtime>(
     app: &AppHandle<R>,
     _api: PluginApi<R, ()>,
     filename: &String,
-    migrations: &[Migration],
 ) -> std::result::Result<(), Box<dyn std::error::Error>> {
     let app_config_folder = app
         .path()
         .app_config_dir()
         .expect("Failed to get an app folder.");
     let connection = connection_for(&app_config_folder, &filename)?;
-    apply_migrations(&connection, &migrations)?;
     app.manage(Mutex::new(connection));
     Ok(())
 }

--- a/src-ui/hooks.client.ts
+++ b/src-ui/hooks.client.ts
@@ -3,8 +3,10 @@ import * as orm from 'drizzle-orm'
 import * as schema from '$lib/db/schema'
 import * as fs from '@tauri-apps/plugin-fs'
 import { commands } from '$lib/generated/sqlite_proxy'
+import { migrate } from '$lib/db/migrator'
 
-declare global {
+
+ declare global {
   interface Window {
     db: typeof db
     schema: typeof schema
@@ -19,3 +21,5 @@ window.schema = schema
 window.orm = orm
 window.fs = fs
 window.sqlite = commands
+
+await migrate(db)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,13 +25,19 @@ fn main() {
         "db:drop" => {
             let db_path = get_full_db_path();
             match remove_file(&db_path) {
-              Ok(_) => info!("Successfully deleted database file at: '{}'", db_path.display().to_string()),
-              Err(_e) => {
-                error!("⚠️ Could not find database at: '{}'.", db_path.display().to_string());
-                error!("  🤔 Is it already dropped?");
-                error!("  🤔 Do you have permissions?");
-                error!("  🤔 Is it the correct path?");
-            }
+                Ok(_) => info!(
+                    "Successfully deleted database file at: '{}'",
+                    db_path.display().to_string()
+                ),
+                Err(_e) => {
+                    error!(
+                        "⚠️ Could not find database at: '{}'.",
+                        db_path.display().to_string()
+                    );
+                    error!("  🤔 Is it already dropped?");
+                    error!("  🤔 Do you have permissions?");
+                    error!("  🤔 Is it the correct path?");
+                }
             };
         }
         "gen:migration" => {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,7 +2,8 @@ extern crate directories;
 extern crate duct;
 
 use duct::cmd;
-use std::env;
+use std::{env, fs::remove_file, path::PathBuf};
+use tauri::utils::platform::Target;
 
 use log::{error, info};
 
@@ -21,6 +22,18 @@ fn main() {
 
     let command = &args[1];
     match command.as_str() {
+        "db:drop" => {
+            let db_path = get_full_db_path();
+            match remove_file(&db_path) {
+              Ok(_) => info!("Successfully deleted database file at: '{}'", db_path.display().to_string()),
+              Err(_e) => {
+                error!("⚠️ Could not find database at: '{}'.", db_path.display().to_string());
+                error!("  🤔 Is it already dropped?");
+                error!("  🤔 Do you have permissions?");
+                error!("  🤔 Is it the correct path?");
+            }
+            };
+        }
         "gen:migration" => {
             if args.len() < 3 {
                 eprintln!("Please provide migration name: `cargo xtask gen:migration [name]`");
@@ -43,4 +56,22 @@ fn main() {
             error!("Unknown command: {}", command);
         }
     }
+}
+
+fn get_full_db_path() -> PathBuf {
+    // TODO(rkofman): replace this with a dynamic value, perhaps stored in a plugin configuration.
+    let db_filename = "books-dev.db";
+    let tauri_config_path = "./src-tauri/tauri.conf.json";
+    let config = tauri::utils::config::parse(Target::current(), tauri_config_path).expect(
+        format!(
+            "This script must be run from project root! Can't find {}",
+            tauri_config_path
+        )
+        .as_str(),
+    );
+    let app_identifier = &config.0.identifier;
+    let project_dirs = directories::ProjectDirs::from_path(app_identifier.into()).unwrap();
+    let app_data_path = project_dirs.data_dir();
+
+    return app_data_path.join(db_filename);
 }


### PR DESCRIPTION
1. The rust code had been left in a non-workable state because not all references to the old code were removed.
2. I hadn't included a way to drop the database. The new migration will likely FAIL if there is already a `books` table -- because it *doesn't* have the `IF NOT EXISTS` addendum.

After you rebase or pull this code, you **must** run `pnpm db:drop` before re-launching the app.