### PR TITLE
Pressing "Enter" should save the currently edited field

### DIFF
--- a/src-ui/lib/components/BooksTableRow.svelte
+++ b/src-ui/lib/components/BooksTableRow.svelte
@@ -3,17 +3,33 @@
 
   export let book: Book
   export let handleEdit: (book: Book, field: keyof Book, event: Event) => void
+
+  const handleEnter = () => (event: Event) => {
+    if (event instanceof KeyboardEvent && event.key === 'Enter') {
+      event.preventDefault?.()
+      ;(event.currentTarget as HTMLTableCellElement).blur?.()
+    }
+  }
 </script>
 
 <tr>
-  <td contenteditable="true" on:blur={(e) => handleEdit(book, 'isbn10', e)}
-    >{book.isbn10 ?? book.isbn13}</td
+  <td
+    contenteditable="true"
+    on:blur={(e) => handleEdit(book, 'isbn10', e)}
+    on:keydown={handleEnter()}>{book.isbn10 ?? book.isbn13}</td
   >
-  <td contenteditable="true" on:blur={(e) => handleEdit(book, 'title', e)}>{book.title || ''} </td>
-  <td contenteditable="true" on:blur={(e) => handleEdit(book, 'authors', e)}
-    >{book.authors?.join(', ') || ''}</td
+  <td
+    contenteditable="true"
+    on:blur={(e) => handleEdit(book, 'title', e)}
+    on:keydown={handleEnter()}
+    >{book?.title || ''}
+  </td>
+  <td
+    contenteditable="true"
+    on:blur={(e) => handleEdit(book, 'authors', e)}
+    on:keydown={handleEnter()}>{book.authors?.join(', ') || ''}</td
   >
-  <td contenteditable="true" on:blur={(e) => handleEdit(book, 'tags', e)}
+  <td contenteditable="true" on:blur={(e) => handleEdit(book, 'tags', e)} on:keydown={handleEnter()}
     >{book.tags?.join(', ') || ''}</td
   >
   <td>


### PR DESCRIPTION
This PR adds a new event handler that checks whether the keydown press is "Enter", and if it is, it prevents the default behavior (creating a new line) and calls "blur" instead, triggering the handleEdit method.