### PR TITLE
Tags fix

### DIFF
--- a/src-ui/lib/components/BooksTable.svelte
+++ b/src-ui/lib/components/BooksTable.svelte
@@ -44,7 +44,7 @@
   const handleEdit = (book: Book, field: keyof Book, e: Event) => {
     const target = e.target as HTMLElement
     const value =
-      field === 'authors'
+      field === 'authors' || 'tags'
         ? target.innerText.split(',').map((author) => author.trim())
         : target.innerText.trim()
 


### PR DESCRIPTION
Tags for books is an array of strings, and the handleEdit method was previously treating it as a single string, causing a rendering issue when trying to call "join" which is an array only method (the books table wouldn't load). This PR updates the method to fix that.