### PR TITLE
Fixed some lint issues.

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,12 +9,12 @@ import globals from 'globals'
 
 export default tseslint.config(
   js.configs.recommended,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+  ...storybook.configs['flat/recommended'],
   ...tseslint.configs.recommendedTypeChecked,
   ...svelte.configs['flat/recommended'],
   prettier,
   ...svelte.configs['flat/prettier'],
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-  ...storybook.configs['flat/recommended'],
   {
     languageOptions: {
       globals: {
@@ -49,6 +49,7 @@ export default tseslint.config(
       'src-ui/lib/generated/',
       'src-ui/lib/drizzle/',
       '!.storybook',
+      'src-tauri/target/',
     ],
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,12 +9,12 @@ import globals from 'globals'
 
 export default tseslint.config(
   js.configs.recommended,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-  ...storybook.configs['flat/recommended'],
   ...tseslint.configs.recommendedTypeChecked,
   ...svelte.configs['flat/recommended'],
   prettier,
   ...svelte.configs['flat/prettier'],
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+  ...storybook.configs['flat/recommended'],
   {
     languageOptions: {
       globals: {

--- a/src-ui/lib/components/BooksTable.svelte
+++ b/src-ui/lib/components/BooksTable.svelte
@@ -41,9 +41,8 @@
       qty: number
     }
   }
-  let promise = $state<Promise<void>>()
   const handleScan = (event: scanEvent): void => {
-    promise = addByISBN(event.detail.scanCode)
+    void addByISBN(event.detail.scanCode)
   }
 
   type ScanAttributes = {

--- a/src-ui/lib/components/BooksTable.svelte
+++ b/src-ui/lib/components/BooksTable.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getByISBN } from '$lib/openLibrary.js'
   import { createBooksStore } from '$lib/state/Books.svelte'
-  import type { Book, NewBook } from '$lib/types/book.js'
+  import type { NewBook } from '$lib/types/book.js'
   import 'bulma/css/bulma.css'
   import onScan from 'onscan.js'
   import type { Action } from 'svelte/action'

--- a/src-ui/lib/components/BooksTable.svelte
+++ b/src-ui/lib/components/BooksTable.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getByISBN } from '$lib/openLibrary.js'
   import { createBooksStore } from '$lib/state/Books.svelte'
-  import type { NewBook } from '$lib/types/book.js'
+  import type { Book, NewBook } from '$lib/types/book.js'
   import 'bulma/css/bulma.css'
   import onScan from 'onscan.js'
   import type { Action } from 'svelte/action'
@@ -23,7 +23,7 @@
           await booksStore.add(initialBook)
         }
       })
-      .catch((err: any) => {
+      .catch((err: unknown) => {
         console.log('Err is: ', err)
       })
   })
@@ -44,17 +44,6 @@
   let promise = $state<Promise<void>>()
   const handleScan = (event: scanEvent): void => {
     promise = addByISBN(event.detail.scanCode)
-  }
-  const handleEdit = async (book: Book, field: keyof Book, e: Event) => {
-    const target = e.target as HTMLElement
-    const value =
-      field === 'authors' || 'tags'
-        ? target.innerText.split(',').map((author) => author.trim())
-        : target.innerText.trim()
-
-    return booksStorePromise.then(async (booksStore) => {
-      await booksStore.edit({ ...book, [field]: value })
-    })
   }
 
   type ScanAttributes = {

--- a/src-ui/lib/components/BooksTableRow.svelte
+++ b/src-ui/lib/components/BooksTableRow.svelte
@@ -6,13 +6,12 @@
   export let book: Book
 
   let booksStorePromise = createBooksStore()
-  console.log(book)
   const handleEdit = async (book: Book, field: keyof Book, e: Event) => {
     const target = e.target as HTMLElement
-    const value =
-      field === 'authors' || 'tags'
-        ? target.innerText.split(',').map((author) => author.trim())
-        : target.innerText.trim()
+    let value: string | string[] = target.innerText.trim()
+    if (field === 'authors' || field == 'tags') {
+      value = target.innerText.split(',').map((author) => author.trim())
+    }
 
     return booksStorePromise.then(async (booksStore) => {
       await booksStore.edit({ ...book, [field]: value })

--- a/src-ui/lib/openLibrary.spec.ts
+++ b/src-ui/lib/openLibrary.spec.ts
@@ -39,7 +39,7 @@ describe('book', () => {
         .then(() => {
           throw new Error('Test failed: Expected a timeout error')
         })
-        .catch((error) => {
+        .catch((error: Error) => {
           expect(error.message).toBe('Fetch request timed out')
         })
     })

--- a/src-ui/lib/openLibrary.ts
+++ b/src-ui/lib/openLibrary.ts
@@ -13,7 +13,7 @@ const fetchWithTimeout = async (request: Request | string, timeout = 3000): Prom
       clearTimeout(timeoutId)
       return response
     })
-    .catch((error) => {
+    .catch((error: Error) => {
       clearTimeout(timeoutId)
       if (error.name === 'AbortError') {
         throw new Error('Fetch request timed out')


### PR DESCRIPTION
This PR fixes some lint issues:

* `src-tauri/target` was producing lint errors even though it's build-generated code that should be ignored
* Minor lint issues around types
* A bug that made all fields outside of `authors` and `tags` fall into the conditional related to them (caught with [no-constant-condition](https://eslint.org/docs/latest/rules/no-constant-condition) rule).
* Leftover tendrils of no longer used code.

~~This doesn't fix _all_ lint issues, but at least some of them require figuring out why Svelte-specific type/lint information seems to be misconfigured; an exercise for a future PR.~~ Actually, what I thought was an erroneous lint was a totally correct issue that I fixed.