### PR TITLE
Use MSW to mock network requests in unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-svelte": "^2.36.0",
     "globals": "^15.0.0",
     "jsdom": "^25.0.1",
+    "msw": "^2.6.4",
     "picocolors": "^1.1.0",
     "prettier": "^3.2.4",
     "prettier-plugin-svelte": "^3.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
+      msw:
+        specifier: ^2.6.4
+        version: 2.6.4(@types/node@22.7.4)(typescript@5.6.2)
       picocolors:
         specifier: ^1.1.0
         version: 1.1.0
@@ -182,7 +185,7 @@ importers:
         version: 5.4.8(@types/node@22.7.4)
       vitest:
         specifier: ^2.0.0
-        version: 2.1.1(@types/node@22.7.4)(jsdom@25.0.1)
+        version: 2.1.1(@types/node@22.7.4)(jsdom@25.0.1)(msw@2.6.4(@types/node@22.7.4)(typescript@5.6.2))
 
 packages:
 
@@ -267,6 +270,15 @@ packages:
   '@babel/types@7.25.6':
     resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
     engines: {node: '>=6.9.0'}
+
+  '@bundled-es-modules/cookie@2.0.1':
+    resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
+
+  '@bundled-es-modules/statuses@1.0.1':
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+
+  '@bundled-es-modules/tough-cookie@0.1.6':
+    resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
 
   '@chromatic-com/storybook@2.0.2':
     resolution: {integrity: sha512-7bPIliISedeIpnVKbzktysFYW5n56bN91kxuOj1XXKixmjbUHRUMvcXd4K2liN6MiR5ZqJtmtcPsZ6CebbGlEA==}
@@ -902,6 +914,16 @@ packages:
     resolution: {integrity: sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==}
     engines: {node: '>=18'}
 
+  '@inquirer/confirm@5.0.2':
+    resolution: {integrity: sha512-KJLUHOaKnNCYzwVbryj3TNBxyZIrr56fR5N45v6K9IPrbT6B7DcudBMfylkV1A8PUdJE15mybkEQyp2/ZUpxUA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+
+  '@inquirer/core@10.1.0':
+    resolution: {integrity: sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==}
+    engines: {node: '>=18'}
+
   '@inquirer/core@9.2.1':
     resolution: {integrity: sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==}
     engines: {node: '>=18'}
@@ -916,6 +938,10 @@ packages:
 
   '@inquirer/figures@1.0.6':
     resolution: {integrity: sha512-yfZzps3Cso2UbM7WlxKwZQh2Hs6plrbjs1QnzQDZhK2DgyCo6D8AaHps9olkNcUFlcYERMqU3uJSp1gmy3s/qQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/figures@1.0.8':
+    resolution: {integrity: sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg==}
     engines: {node: '>=18'}
 
   '@inquirer/input@3.0.1':
@@ -949,6 +975,12 @@ packages:
   '@inquirer/type@2.0.0':
     resolution: {integrity: sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==}
     engines: {node: '>=18'}
+
+  '@inquirer/type@3.0.1':
+    resolution: {integrity: sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -993,6 +1025,10 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
+  '@mswjs/interceptors@0.36.10':
+    resolution: {integrity: sha512-GXrJgakgJW3DWKueebkvtYgGKkxA7s0u5B0P5syJM5rvQUnrpLPigvci8Hukl7yEM+sU06l+er2Fgvx/gmiRgg==}
+    engines: {node: '>=18'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1004,6 +1040,15 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1570,6 +1615,12 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/statuses@2.0.5':
+    resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2210,6 +2261,10 @@ packages:
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   core-util-is@1.0.3:
@@ -3221,6 +3276,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphql@16.9.0:
+    resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
 
@@ -3263,6 +3322,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
@@ -3437,6 +3499,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
@@ -3860,9 +3925,23 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.6.4:
+    resolution: {integrity: sha512-Pm4LmWQeytDsNCR+A7gt39XAdtH6zQb6jnIKRig0FlvYOn8eksn3s1nXxUfz5KYUjbckof7Z4p2ewzgffPoCbg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
@@ -3983,6 +4062,9 @@ packages:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -4079,6 +4161,9 @@ packages:
 
   path-to-regexp@0.1.10:
     resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -4198,6 +4283,9 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  psl@1.10.0:
+    resolution: {integrity: sha512-KSKHEbjAnpUuAUserOq0FxGXCUrzC3WniuSJhvdbs102rL55266ZcHBqLWOsG30spQMlPdpy7icATiAQehg/iA==}
+
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
 
@@ -4211,6 +4299,9 @@ packages:
 
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4329,6 +4420,9 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -4578,6 +4672,9 @@ packages:
   streamx@2.20.1:
     resolution: {integrity: sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==}
 
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -4801,6 +4898,10 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tough-cookie@5.0.0:
     resolution: {integrity: sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==}
     engines: {node: '>=16'}
@@ -4956,6 +5057,10 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -4981,6 +5086,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   urlpattern-polyfill@10.0.0:
     resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
@@ -5408,6 +5516,19 @@ snapshots:
       to-fast-properties: 2.0.0
     optional: true
 
+  '@bundled-es-modules/cookie@2.0.1':
+    dependencies:
+      cookie: 0.7.2
+
+  '@bundled-es-modules/statuses@1.0.1':
+    dependencies:
+      statuses: 2.0.1
+
+  '@bundled-es-modules/tough-cookie@0.1.6':
+    dependencies:
+      '@types/tough-cookie': 4.0.5
+      tough-cookie: 4.1.4
+
   '@chromatic-com/storybook@2.0.2(react@18.3.1)':
     dependencies:
       chromatic: 11.10.4
@@ -5793,6 +5914,26 @@ snapshots:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 2.0.0
 
+  '@inquirer/confirm@5.0.2(@types/node@22.7.4)':
+    dependencies:
+      '@inquirer/core': 10.1.0(@types/node@22.7.4)
+      '@inquirer/type': 3.0.1(@types/node@22.7.4)
+      '@types/node': 22.7.4
+
+  '@inquirer/core@10.1.0(@types/node@22.7.4)':
+    dependencies:
+      '@inquirer/figures': 1.0.8
+      '@inquirer/type': 3.0.1(@types/node@22.7.4)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@inquirer/core@9.2.1':
     dependencies:
       '@inquirer/figures': 1.0.6
@@ -5821,6 +5962,8 @@ snapshots:
       yoctocolors-cjs: 2.1.2
 
   '@inquirer/figures@1.0.6': {}
+
+  '@inquirer/figures@1.0.8': {}
 
   '@inquirer/input@3.0.1':
     dependencies:
@@ -5875,6 +6018,10 @@ snapshots:
   '@inquirer/type@2.0.0':
     dependencies:
       mute-stream: 1.0.0
+
+  '@inquirer/type@3.0.1(@types/node@22.7.4)':
+    dependencies:
+      '@types/node': 22.7.4
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -5931,6 +6078,15 @@ snapshots:
       '@types/react': 18.3.9
       react: 18.3.1
 
+  '@mswjs/interceptors@0.36.10':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -5942,6 +6098,15 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -6611,6 +6776,10 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
+  '@types/statuses@2.0.5': {}
+
+  '@types/tough-cookie@4.0.5': {}
+
   '@types/unist@3.0.3': {}
 
   '@types/uuid@10.0.0': {}
@@ -6783,12 +6952,13 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(vite@5.4.8(@types/node@22.7.4))':
+  '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(msw@2.6.4(@types/node@22.7.4)(typescript@5.6.2))(vite@5.4.8(@types/node@22.7.4))':
     dependencies:
       '@vitest/spy': 2.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.12
     optionalDependencies:
+      msw: 2.6.4(@types/node@22.7.4)(typescript@5.6.2)
       vite: 5.4.8(@types/node@22.7.4)
 
   '@vitest/pretty-format@2.0.5':
@@ -7463,6 +7633,8 @@ snapshots:
   cookie-signature@1.0.6: {}
 
   cookie@0.6.0: {}
+
+  cookie@0.7.2: {}
 
   core-util-is@1.0.3: {}
 
@@ -8735,6 +8907,8 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql@16.9.0: {}
+
   has-bigints@1.0.2: {}
 
   has-flag@3.0.0: {}
@@ -8770,6 +8944,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   he@1.2.0: {}
+
+  headers-polyfill@4.0.3: {}
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -8945,6 +9121,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.0.7:
     dependencies:
@@ -9364,7 +9542,34 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.6.4(@types/node@22.7.4)(typescript@5.6.2):
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.1
+      '@bundled-es-modules/statuses': 1.0.1
+      '@bundled-es-modules/tough-cookie': 0.1.6
+      '@inquirer/confirm': 5.0.2(@types/node@22.7.4)
+      '@mswjs/interceptors': 0.36.10
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.5
+      chalk: 4.1.2
+      graphql: 16.9.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      strict-event-emitter: 0.5.1
+      type-fest: 4.26.1
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.6.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   mute-stream@1.0.0: {}
+
+  mute-stream@2.0.0: {}
 
   nanoid@3.3.7: {}
 
@@ -9488,6 +9693,8 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
+  outvariant@1.4.3: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -9583,6 +9790,8 @@ snapshots:
       minipass: 7.1.2
 
   path-to-regexp@0.1.10: {}
+
+  path-to-regexp@6.3.0: {}
 
   pathe@1.1.2: {}
 
@@ -9703,6 +9912,10 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  psl@1.10.0:
+    dependencies:
+      punycode: 2.3.1
+
   pump@3.0.2:
     dependencies:
       end-of-stream: 1.4.4
@@ -9715,6 +9928,8 @@ snapshots:
       side-channel: 1.0.6
 
   query-selector-shadow-dom@1.0.1: {}
+
+  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -9869,6 +10084,8 @@ snapshots:
       unist-util-visit: 5.0.0
 
   require-directory@2.1.1: {}
+
+  requires-port@1.0.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -10165,6 +10382,8 @@ snapshots:
     optionalDependencies:
       bare-events: 2.5.0
 
+  strict-event-emitter@0.5.1: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -10406,6 +10625,13 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.10.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tough-cookie@5.0.0:
     dependencies:
       tldts: 6.1.57
@@ -10571,6 +10797,8 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
+  universalify@0.2.0: {}
+
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
@@ -10590,6 +10818,11 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   urlpattern-polyfill@10.0.0: {}
 
@@ -10653,10 +10886,10 @@ snapshots:
     optionalDependencies:
       vite: 5.4.8(@types/node@22.7.4)
 
-  vitest@2.1.1(@types/node@22.7.4)(jsdom@25.0.1):
+  vitest@2.1.1(@types/node@22.7.4)(jsdom@25.0.1)(msw@2.6.4(@types/node@22.7.4)(typescript@5.6.2)):
     dependencies:
       '@vitest/expect': 2.1.1
-      '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(vite@5.4.8(@types/node@22.7.4))
+      '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(msw@2.6.4(@types/node@22.7.4)(typescript@5.6.2))(vite@5.4.8(@types/node@22.7.4))
       '@vitest/pretty-format': 2.1.1
       '@vitest/runner': 2.1.1
       '@vitest/snapshot': 2.1.1

--- a/src-ui/lib/openLibrary.spec.ts
+++ b/src-ui/lib/openLibrary.spec.ts
@@ -1,7 +1,164 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
 import { getByISBN } from './openLibrary'
+import { mockServer } from '../testing/msw-setup'
 
 describe('book', () => {
+  beforeEach(() => {
+    mockServer.use(
+      http.get('https://openlibrary.org/isbn/9780441004225.json', () => {
+        return HttpResponse.json({
+          identifiers: {
+            goodreads: ['64396'],
+            librarything: ['52023'],
+          },
+          title: 'Adventures of the Stainless Steel Rat',
+          authors: [
+            {
+              key: '/authors/OL27278A',
+            },
+          ],
+          publish_date: 'October 1996',
+          publishers: ['Ace Books'],
+          covers: [283622],
+          languages: [
+            {
+              key: '/languages/eng',
+            },
+          ],
+          type: {
+            key: '/type/edition',
+          },
+          local_id: ['urn:bwbsku:T2-AQV-123', 'urn:bwbsku:086-BAC-919'],
+          source_records: [
+            'promise:bwb_daily_pallets_2021-07-15:T2-AQV-123',
+            'bwb:9780441004225',
+            'promise:bwb_daily_pallets_2021-05-14:086-BAC-919',
+          ],
+          key: '/books/OL7524009M',
+          works: [
+            {
+              key: '/works/OL467275W',
+            },
+          ],
+          classifications: {},
+          series: ['The Stainless Steel Rat'],
+          ocaid: 'adventuresofstai00harr_0',
+          isbn_10: ['0441004229'],
+          isbn_13: ['9780441004225'],
+          oclc_numbers: ['20230277'],
+          number_of_pages: 402,
+          latest_revision: 21,
+          revision: 21,
+          created: {
+            type: '/type/datetime',
+            value: '2008-04-29T13:35:46.876380',
+          },
+          last_modified: {
+            type: '/type/datetime',
+            value: '2024-05-29T21:37:41.873318',
+          },
+        })
+      }),
+      http.get('https://openlibrary.org/books/OL7524009M.json', () => {
+        return HttpResponse.json({
+          identifiers: {
+            goodreads: ['64396'],
+            librarything: ['52023'],
+          },
+          title: 'Adventures of the Stainless Steel Rat',
+          authors: [
+            {
+              key: '/authors/OL27278A',
+            },
+          ],
+          publish_date: 'October 1996',
+          publishers: ['Ace Books'],
+          covers: [283622],
+          languages: [
+            {
+              key: '/languages/eng',
+            },
+          ],
+          type: {
+            key: '/type/edition',
+          },
+          local_id: ['urn:bwbsku:T2-AQV-123', 'urn:bwbsku:086-BAC-919'],
+          source_records: [
+            'promise:bwb_daily_pallets_2021-07-15:T2-AQV-123',
+            'bwb:9780441004225',
+            'promise:bwb_daily_pallets_2021-05-14:086-BAC-919',
+          ],
+          key: '/books/OL7524009M',
+          works: [
+            {
+              key: '/works/OL467275W',
+            },
+          ],
+          classifications: {},
+          series: ['The Stainless Steel Rat'],
+          ocaid: 'adventuresofstai00harr_0',
+          isbn_10: ['0441004229'],
+          isbn_13: ['9780441004225'],
+          oclc_numbers: ['20230277'],
+          number_of_pages: 402,
+          latest_revision: 21,
+          revision: 21,
+          created: {
+            type: '/type/datetime',
+            value: '2008-04-29T13:35:46.876380',
+          },
+          last_modified: {
+            type: '/type/datetime',
+            value: '2024-05-29T21:37:41.873318',
+          },
+        })
+      }),
+      http.get('https://openlibrary.org/authors/OL27278A.json', () => {
+        return HttpResponse.json({
+          name: 'Harry Harrison',
+          bio: 'Harry Max Harrison was born Henry Maxwell Dempsey in Stamford, Connecticut. He moved with his family to New York early in his childhood. On his 18th birthday, having graduated from high school, he was drafted into the U.S. Army Air Corps, and serves as an armourer, gunnery instructor, truck driver, and military police officer. When the war ended, he became an art student at both the Hunter College in New York City and the Cartoonists and Illustrators School. Upon graduation, he became a freelance graphic artist, providing illustrations for book covers, magazines, and comic books such as Weird Fantasy and Weird Science. He also began contributing articles to these magazines. In 1952, he moved into editing pulp magazines such as Amazing Stories and Fantastic. In 1954 he married, and their first child was born in 1955. In 1956 he became a full-time writer, and began working on his first book in addition to writing for other publications such as The Saint syndicated comic strips. Over the next decade he and his family moved to several places, including Mexico, England, Italy, back to New York for the birth of their second child in 1959, to Denmark for seven years, back to England in 1965, San Diego in 1967, and finally Ireland in 1975 where they settled. Harrison produced over 60 books, occasionally in collaboration with other well-known writers such as Gordon R. Dickson.',
+          birth_date: '12 March 1925',
+          wikipedia: 'http://en.wikipedia.org/wiki/Harry_Harrison',
+          type: {
+            key: '/type/author',
+          },
+          source_records: ['amazon:0722143443', 'amazon:0722143559'],
+          alternate_names: ['Hank Dempsey'],
+          remote_ids: {
+            isni: '0000000368644868',
+            viaf: '80169724',
+            wikidata: 'Q489193',
+          },
+          title: 'pseud. van Henry Maxwell Dempsey',
+          death_date: '15 August 2012',
+          personal_name: 'Harry Harrison',
+          location: 'Dublin, Ireland',
+          photos: [14595114, 5539267],
+          links: [
+            {
+              title: 'Website',
+              url: 'http://www.harryharrison.com/',
+              type: {
+                key: '/type/link',
+              },
+            },
+          ],
+          key: '/authors/OL27278A',
+          latest_revision: 15,
+          revision: 15,
+          created: {
+            type: '/type/datetime',
+            value: '2008-04-01T03:28:50.625462',
+          },
+          last_modified: {
+            type: '/type/datetime',
+            value: '2024-08-26T09:38:15.526497',
+          },
+        })
+      })
+    )
+  })
   describe('#getByISBN', () => {
     const isbn = '9780441004225'
     it('should be able to retrieve The Stainless Steel Rat (9780441004225)', async () => {

--- a/src-ui/lib/state/Books.spec.ts
+++ b/src-ui/lib/state/Books.spec.ts
@@ -1,8 +1,10 @@
-import { expect, describe, it, beforeEach, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { expect, describe, it, beforeEach, afterEach, beforeAll } from 'vitest'
 import { createTestBooksStore, type BooksStore } from './Books.svelte.js'
 import { type Book, type NewBook } from '$lib/types/book.js'
 import { createTestDB } from '$lib/db/test_helpers.js'
 import type { Database } from 'sql.js'
+import { mockServer } from '../../testing/msw-setup.js'
 
 const duneMessiah: NewBook = {
   isbn10: '0441172695',
@@ -36,6 +38,116 @@ describe('booksStore', () => {
     const { drizzle, sqlite } = createTestDB()
     db = sqlite
     booksStore = await createTestBooksStore(drizzle)
+    mockServer.use(
+      http.get('https://openlibrary.org/isbn/9780441004225.json', () => {
+        return HttpResponse.json({
+          identifiers: {
+            goodreads: ['64396'],
+            librarything: ['52023'],
+          },
+          title: 'Adventures of the Stainless Steel Rat',
+          authors: [
+            {
+              key: '/authors/OL27278A',
+            },
+          ],
+          publish_date: 'October 1996',
+          publishers: ['Ace Books'],
+          covers: [283622],
+          languages: [
+            {
+              key: '/languages/eng',
+            },
+          ],
+          type: {
+            key: '/type/edition',
+          },
+          local_id: ['urn:bwbsku:T2-AQV-123', 'urn:bwbsku:086-BAC-919'],
+          source_records: [
+            'promise:bwb_daily_pallets_2021-07-15:T2-AQV-123',
+            'bwb:9780441004225',
+            'promise:bwb_daily_pallets_2021-05-14:086-BAC-919',
+          ],
+          key: '/books/OL7524009M',
+          works: [
+            {
+              key: '/works/OL467275W',
+            },
+          ],
+          classifications: {},
+          series: ['The Stainless Steel Rat'],
+          ocaid: 'adventuresofstai00harr_0',
+          isbn_10: ['0441004229'],
+          isbn_13: ['9780441004225'],
+          oclc_numbers: ['20230277'],
+          number_of_pages: 402,
+          latest_revision: 21,
+          revision: 21,
+          created: {
+            type: '/type/datetime',
+            value: '2008-04-29T13:35:46.876380',
+          },
+          last_modified: {
+            type: '/type/datetime',
+            value: '2024-05-29T21:37:41.873318',
+          },
+        })
+      }),
+      http.get('https://openlibrary.org/books/OL7524009M.json', () => {
+        return HttpResponse.json({
+          identifiers: {
+            goodreads: ['64396'],
+            librarything: ['52023'],
+          },
+          title: 'Adventures of the Stainless Steel Rat',
+          authors: [
+            {
+              key: '/authors/OL27278A',
+            },
+          ],
+          publish_date: 'October 1996',
+          publishers: ['Ace Books'],
+          covers: [283622],
+          languages: [
+            {
+              key: '/languages/eng',
+            },
+          ],
+          type: {
+            key: '/type/edition',
+          },
+          local_id: ['urn:bwbsku:T2-AQV-123', 'urn:bwbsku:086-BAC-919'],
+          source_records: [
+            'promise:bwb_daily_pallets_2021-07-15:T2-AQV-123',
+            'bwb:9780441004225',
+            'promise:bwb_daily_pallets_2021-05-14:086-BAC-919',
+          ],
+          key: '/books/OL7524009M',
+          works: [
+            {
+              key: '/works/OL467275W',
+            },
+          ],
+          classifications: {},
+          series: ['The Stainless Steel Rat'],
+          ocaid: 'adventuresofstai00harr_0',
+          isbn_10: ['0441004229'],
+          isbn_13: ['9780441004225'],
+          oclc_numbers: ['20230277'],
+          number_of_pages: 402,
+          latest_revision: 21,
+          revision: 21,
+          created: {
+            type: '/type/datetime',
+            value: '2008-04-29T13:35:46.876380',
+          },
+          last_modified: {
+            type: '/type/datetime',
+            value: '2024-05-29T21:37:41.873318',
+          },
+        })
+      })
+    )
   })
 
   afterEach(() => {

--- a/src-ui/testing/msw-setup.ts
+++ b/src-ui/testing/msw-setup.ts
@@ -1,0 +1,13 @@
+import { afterAll, afterEach, beforeAll } from 'vitest'
+import { setupServer } from 'msw/node'
+
+export const mockServer = setupServer()
+
+// Start server before all tests
+beforeAll(() => mockServer.listen({ onUnhandledRequest: 'error' }))
+
+//  Close server after all tests
+afterAll(() => mockServer.close())
+
+// Reset handlers after each test `important for test isolation`
+afterEach(() => mockServer.resetHandlers())

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     diff: './vitest.diff.ts',
     environment: 'jsdom',
+    setupFiles: ['./src-ui/testing/msw-setup.ts'],
   },
 })


### PR DESCRIPTION
This PR adds the [msw](https://mswjs.io/) library and uses it for request mocking. The resulting code isn't very pretty because the entire response JSON is in each unit test file, but it works.

A future cleanup can move some of the simplest GET mocks into a centralized place out of the way (since they're pretty static responses that aren't affected by the code under test at all). But for now, this is good enough to get stable tests.