### PR TITLE
Fix storybook configuration

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/sveltekit'
 
 const config: StorybookConfig = {
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|ts|svelte)'],
+  stories: ['../src-ui/stories/**/*.mdx', '../src-ui/stories/**/*.stories.@(js|ts|svelte)'],
   addons: [
     '@storybook/addon-svelte-csf',
     '@storybook/addon-links',

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/sveltekit'
 
 const config: StorybookConfig = {
-  stories: ['../src-ui/stories/**/*.mdx', '../src-ui/stories/**/*.stories.@(js|ts|svelte)'],
+  stories: ['../src-ui/**/*.mdx', '../src-ui/**/*.stories.@(js|ts|svelte)'],
   addons: [
     '@storybook/addon-svelte-csf',
     '@storybook/addon-links',

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "svelte:dev": "vite dev",
     "svelte:build": "vite build",
     "svelte:preview": "vite preview",
-    "storybook": "pnpx run storybook:dev",
+    "storybook": "pnpm storybook:dev",
     "storybook:dev": "storybook dev -p 6006",
     "storybook:build": "storybook build"
   },


### PR DESCRIPTION
Smol fixes to make storybook actually render its auto-generated component stories:

<img width="1357" alt="Screenshot 2024-11-14 at 6 34 10 PM" src="https://github.com/user-attachments/assets/8710365a-cda5-435c-a810-f9dcf619636e">
