### PR TITLE
Simplify the books store

### DIFF
--- a/src-ui/hooks.client.ts
+++ b/src-ui/hooks.client.ts
@@ -4,7 +4,7 @@ import * as schema from '$lib/db/schema'
 import * as fs from '@tauri-apps/plugin-fs'
 import { commands } from '$lib/generated/sqlite_proxy'
 import { migrate } from '$lib/db/migrator'
-import { getBooksStore } from '$lib/state/Books.svelte'
+import { getBooksStore, type BooksStore } from '$lib/state/Books.svelte'
 
 declare global {
   interface Window {
@@ -13,6 +13,8 @@ declare global {
     orm: typeof orm
     fs: typeof fs
     sqlite: typeof commands
+    booksStore: BooksStore
+
   }
 }
 
@@ -23,4 +25,4 @@ window.fs = fs
 window.sqlite = commands
 
 await migrate(db)
-window.booksStore = await getBooksStore()
+window.booksStore = getBooksStore()

--- a/src-ui/hooks.client.ts
+++ b/src-ui/hooks.client.ts
@@ -4,7 +4,7 @@ import * as schema from '$lib/db/schema'
 import * as fs from '@tauri-apps/plugin-fs'
 import { commands } from '$lib/generated/sqlite_proxy'
 import { migrate } from '$lib/db/migrator'
-import { createBooksStore } from '$lib/state/Books.svelte'
+import { getBooksStore } from '$lib/state/Books.svelte'
 
 declare global {
   interface Window {
@@ -23,4 +23,4 @@ window.fs = fs
 window.sqlite = commands
 
 await migrate(db)
-window.booksStore = await createBooksStore()
+window.booksStore = await getBooksStore()

--- a/src-ui/lib/components/BooksTable.svelte
+++ b/src-ui/lib/components/BooksTable.svelte
@@ -1,37 +1,15 @@
 <script lang="ts">
   import { getByISBN } from '$lib/openLibrary.js'
-  import { createBooksStore } from '$lib/state/Books.svelte'
-  import type { NewBook } from '$lib/types/book.js'
+  import { getBooksStore } from '$lib/state/Books.svelte'
   import onScan from 'onscan.js'
   import type { Action } from 'svelte/action'
   import BooksTableRow from './BooksTableRow.svelte'
 
-  let booksStorePromise = createBooksStore()
-
-  $effect(() => {
-    const initialBook: NewBook = {
-      isbn10: '1234567890',
-      title: 'Hunting Prince Dracula',
-      tags: ['Young Adult', 'Fiction'],
-      authors: ['Kerri Maniscalco'],
-      hasRead: true,
-    }
-    void booksStorePromise
-      .then(async (booksStore) => {
-        if (booksStore.value.length === 0) {
-          await booksStore.add(initialBook)
-        }
-      })
-      .catch((err: unknown) => {
-        console.log('Err is: ', err)
-      })
-  })
+  let booksStore = getBooksStore()
 
   const addByISBN = async (isbn: string): Promise<void> => {
-    return booksStorePromise.then(async (booksStore) => {
-      const book = await getByISBN(isbn)
-      await booksStore.add(book)
-    })
+    const book = await getByISBN(isbn)
+    await booksStore.add(book)
   }
 
   type scanEvent = {
@@ -59,9 +37,9 @@
 </script>
 
 <svelte:document use:listenForBarcodes on:scan={handleScan} />
-{#await booksStorePromise}
+{#if !booksStore.initialized}
   ...initial loading of books...
-{:then booksStore}
+{:else}
   <table class="table is-fullwidth">
     <thead>
       <tr>
@@ -81,7 +59,7 @@
         <tr>
           <td colspan="7">
             <section class="section">
-              <div class="content has-text-grey has-text-centered">
+              <div class="content has-text-soft has-text-centered">
                 <p><i class="far fa-3x fa-frown"></i></p>
                 <p>No books</p>
               </div>
@@ -91,4 +69,4 @@
       {/each}
     </tbody>
   </table>
-{/await}
+{/if}

--- a/src-ui/lib/components/BooksTableRow.svelte
+++ b/src-ui/lib/components/BooksTableRow.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import { createBooksStore } from '$lib/state/Books.svelte'
+  import { getBooksStore } from '$lib/state/Books.svelte'
   import type { Book } from '$lib/types/book.js'
   import { fade } from 'svelte/transition'
   import Button from './core/Button.svelte'
 
   export let book: Book
 
-  let booksStorePromise = createBooksStore()
+  let booksStore = getBooksStore()
   const handleEdit = async (book: Book, field: keyof Book, e: Event) => {
     const target = e.target as HTMLElement
     let value: string | string[] = target.innerText.trim()
@@ -14,14 +14,10 @@
       value = target.innerText.split(',').map((author) => author.trim())
     }
 
-    return booksStorePromise.then(async (booksStore) => {
-      await booksStore.edit({ ...book, [field]: value })
-    })
+    await booksStore.edit({ ...book, [field]: value })
   }
   const removeBook = async (id: string): Promise<void> => {
-    return booksStorePromise.then(async (booksStore) => {
-      await booksStore.remove(id)
-    })
+    await booksStore.remove(id)
   }
 
   const handleEnter = () => (event: Event) => {
@@ -41,10 +37,10 @@
   <td
     contenteditable="true"
     on:blur={(e) => handleEdit(book, 'isbn10', e)}
-    on:keydown={handleEnter()}>{book.isbn10 ?? book.isbn13}</td
+    on:keydown={handleEnter()}>{book.isbn10}</td
   >
-  <td contenteditable="true" on:blur={(e) => handleEdit(book, 'isbn10', e)}
-    >{book.isbn10 ?? book.isbn13}</td
+  <td contenteditable="true" on:blur={(e) => handleEdit(book, 'isbn13', e)}
+    >{book.isbn13}</td
   >
   <td
     contenteditable="true"

--- a/src-ui/lib/state/Books.spec.ts
+++ b/src-ui/lib/state/Books.spec.ts
@@ -34,10 +34,10 @@ let booksStore: BooksStore
 let db: Database
 
 describe('booksStore', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     const { drizzle, sqlite } = createTestDB()
     db = sqlite
-    booksStore = await createTestBooksStore(drizzle)
+    booksStore = createTestBooksStore(drizzle)
     mockServer.use(
       http.get('https://openlibrary.org/isbn/9780441004225.json', () => {
         return HttpResponse.json({

--- a/src-ui/lib/state/Books.svelte.ts
+++ b/src-ui/lib/state/Books.svelte.ts
@@ -6,22 +6,24 @@ import type { SqliteRemoteDatabase } from 'drizzle-orm/sqlite-proxy'
 import { eq } from 'drizzle-orm/sql/expressions/conditions'
 
 class BooksStore {
-  private constructor(private db: SqliteRemoteDatabase<typeof schema>) {}
-  static async create(db: SqliteRemoteDatabase<typeof schema>) {
-    const store = new BooksStore(db)
-    await store.reload()
-    return store
+  constructor(private db: SqliteRemoteDatabase<typeof schema>) {
+    void this.reload().then(() => { this.#initialized = true })
   }
 
+  static create(db: SqliteRemoteDatabase<typeof schema>) {
+    return new BooksStore(db)
+  }
+
+  #initialized = $state(false)
   #value = $state<Book[]>([])
+
+  get initialized(): boolean {
+    return this.#initialized
+  }
 
   get value(): Book[] {
     return this.#value
   }
-  // TODO(rkofman): set was removed because it doesn't make sense w/ a DB backed store.
-  // but it implies I will need to rewrite some tests -- which is needed anyway, because
-  // making them be unit-tests would be hard here.
-
   async add(book: NewBook): Promise<string> {
     // NOTE (isummit): we're using a library instead of window.crypto because window.crypto.randomUUID is
     // not available for older versions of macOs webviews, which some of our users may be on (macOs v11.1)
@@ -53,17 +55,17 @@ class BooksStore {
   }
 }
 
-let booksStorePromise: Promise<BooksStore>
-export async function createBooksStore(): Promise<BooksStore> {
-  if (booksStorePromise === undefined) {
-    booksStorePromise = BooksStore.create(realDb)
+let booksStore: BooksStore
+export function getBooksStore(): BooksStore {
+  if (booksStore === undefined) {
+    booksStore = new BooksStore(realDb)
   }
-  return booksStorePromise
+  return booksStore
 }
 
-export async function createTestBooksStore(
+export function createTestBooksStore(
   testDb: SqliteRemoteDatabase<typeof schema>
-): Promise<BooksStore> {
-  return BooksStore.create(testDb)
+): BooksStore {
+  return new BooksStore(testDb)
 }
 export type { BooksStore }


### PR DESCRIPTION
Simplify our interactions with the BooksStore by allowing it to be empty when initialized as it awaits the first update from sqlite. Introduces an `initialized` boolean to communicate when that first load is completed.