### PR TITLE
Manually run js:format to catch up with formatting nits.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ pnpm-lock.yaml
 yarn.lock
 src-ui/lib/drizzle
 src-ui/lib/generated
+migrations/

--- a/src-ui/hooks.client.ts
+++ b/src-ui/hooks.client.ts
@@ -14,7 +14,6 @@ declare global {
     fs: typeof fs
     sqlite: typeof commands
     booksStore: BooksStore
-
   }
 }
 

--- a/src-ui/lib/components/BooksTableRow.svelte
+++ b/src-ui/lib/components/BooksTableRow.svelte
@@ -27,12 +27,14 @@
     }
   }
 
-
-  async function toggleRead(event: Event & { currentTarget: EventTarget & HTMLInputElement }, book: Book) {
+  async function toggleRead(
+    event: Event & { currentTarget: EventTarget & HTMLInputElement },
+    book: Book
+  ) {
     // TODO(rkofman): instead of updating the whole book element, there should be a method on the store
     // to set the single field to a new value; filtered by ID.
     const readAt = book.readAt ? null : new Date()
-    await booksStore.edit({...book, readAt})
+    await booksStore.edit({ ...book, readAt })
   }
 </script>
 
@@ -42,29 +44,27 @@
     ><Button aria-label="delete book" class="delete" onclick={() => removeBook(book.id)}
     ></Button></td
   >
-  <td
-    contenteditable="true"
-    onblur={(e) => handleEdit(book, 'isbn10', e)}
-    onkeydown={handleEnter}>{book.isbn10}</td
+  <td contenteditable="true" onblur={(e) => handleEdit(book, 'isbn10', e)} onkeydown={handleEnter}
+    >{book.isbn10}</td
   >
   <td contenteditable="true" onblur={(e) => handleEdit(book, 'isbn13', e)}>{book.isbn13}</td>
-  <td
-    contenteditable="true"
-    onblur={(e) => handleEdit(book, 'title', e)}
-    onkeydown={handleEnter}
+  <td contenteditable="true" onblur={(e) => handleEdit(book, 'title', e)} onkeydown={handleEnter}
     >{book?.title || ''}
   </td>
-  <td
-    contenteditable="true"
-    onblur={(e) => handleEdit(book, 'authors', e)}
-    onkeydown={handleEnter}>{book.authors?.join(', ') || ''}</td
+  <td contenteditable="true" onblur={(e) => handleEdit(book, 'authors', e)} onkeydown={handleEnter}
+    >{book.authors?.join(', ') || ''}</td
   >
   <td contenteditable="true" onblur={(e) => handleEdit(book, 'tags', e)} onkeydown={handleEnter}
     >{book.tags?.join(', ') || ''}</td
   >
   <td>
     <label class="b-checkbox checkbox is-regular m-1">
-      <input type="checkbox" value="false" checked={!!book.readAt} onchange={(e) => toggleRead(e, book)}>
+      <input
+        type="checkbox"
+        value="false"
+        checked={!!book.readAt}
+        onchange={(e) => toggleRead(e, book)}
+      />
       <span class="check"></span>
       <!-- <span class="control-label"></span> -->
     </label>

--- a/src-ui/lib/db/schema.ts
+++ b/src-ui/lib/db/schema.ts
@@ -14,7 +14,7 @@ export const books = sqliteTable('books', {
   publicationDate: text(),
   copyrightDate: text(),
   coverImages: text({ mode: 'json' }).$type<{ small?: string; medium?: string; large?: string }>(),
-  readAt: integer({mode: 'timestamp'}),
+  readAt: integer({ mode: 'timestamp' }),
   createdAt: integer({ mode: 'timestamp' })
     .notNull()
     .default(sql`(unixepoch())`),

--- a/src-ui/routes/+page.svelte
+++ b/src-ui/routes/+page.svelte
@@ -11,7 +11,7 @@
       '9780316514828': 'Hunting Prince Dracula',
       '978-0307292063': 'The Foundation Trilogy',
       '9780553418026': 'The Martian',
-      '978-0593818749': 'We\'ll Prescribe You a Cat',
+      '978-0593818749': "We'll Prescribe You a Cat",
       '9781250214713': 'All Systems Red',
     }
     const isbn = _(sampleBooks).keys().sample() as string
@@ -28,9 +28,7 @@
     <h1 class="title">Your Friendly Book Catalog</h1>
   </div>
   <div class="level-right">
-    <Button primary onclick={simulateScan}>
-      📖 Simulate ISBN
-    </Button>
+    <Button primary onclick={simulateScan}>📖 Simulate ISBN</Button>
     <Button primary onclick={handleAddBookClick}>Add Book</Button>
   </div>
 </div>


### PR DESCRIPTION
This PR also adds the `migrations` folder to `.prettierignore`.