### PR TITLE
Fix visual bug when editing previously empty fields.

### DIFF
--- a/src-ui/lib/components/BooksTableRow.svelte
+++ b/src-ui/lib/components/BooksTableRow.svelte
@@ -9,14 +9,8 @@
   export let book: Book
 
   let booksStore = getBooksStore()
-  const handleEdit = async (book: Book, field: keyof Book, e: Event | string) => {
-    let value: string | string[]
-    if (typeof e === 'object') {
-      const target = e.target as HTMLElement
-      value = target.innerText.trim()
-    } else {
-      value = e
-    }
+  const handleEdit = async (book: Book, field: keyof Book, valueStr: string) => {
+    let value: string | string[] = valueStr.trim()
 
     if (field === 'authors') {
       value = value.split(',').map(trim)
@@ -32,13 +26,6 @@
 
   const removeBook = async (id: string): Promise<void> => {
     await booksStore.remove(id)
-  }
-
-  function handleEnter(event: Event) {
-    if (event instanceof KeyboardEvent && event.key === 'Enter') {
-      event.preventDefault?.()
-      ;(event.currentTarget as HTMLTableCellElement).blur?.()
-    }
   }
 
   async function toggleRead(

--- a/src-ui/lib/components/BooksTableRow.svelte
+++ b/src-ui/lib/components/BooksTableRow.svelte
@@ -4,15 +4,22 @@
   import { fade } from 'svelte/transition'
   import Button from './core/Button.svelte'
   import { trim } from 'lodash'
+  import EditableTd from './core/EditableTd.svelte'
 
   export let book: Book
 
   let booksStore = getBooksStore()
-  const handleEdit = async (book: Book, field: keyof Book, e: Event) => {
-    const target = e.target as HTMLElement
-    let value: string | string[] = target.innerText.trim()
+  const handleEdit = async (book: Book, field: keyof Book, e: Event | string) => {
+    let value: string | string[]
+    if (typeof e === 'object') {
+      const target = e.target as HTMLElement
+      value = target.innerText.trim()
+    } else {
+      value = e
+    }
+
     if (field === 'authors') {
-      value = target.innerText.split(',').map(trim)
+      value = value.split(',').map(trim)
     }
 
     await booksStore.edit({ ...book, [field]: value })
@@ -51,21 +58,26 @@
     ><Button aria-label="delete book" class="delete" onclick={() => removeBook(book.id)}
     ></Button></td
   >
-  <td contenteditable="true" onblur={(e) => handleEdit(book, 'isbn10', e)} onkeydown={handleEnter}
-    >{book.isbn10}</td
-  >
-  <td contenteditable="true" onblur={(e) => handleEdit(book, 'isbn13', e)}>{book.isbn13}</td>
-  <td contenteditable="true" onblur={(e) => handleEdit(book, 'title', e)} onkeydown={handleEnter}
-    >{book?.title || ''}
-  </td>
-  <td contenteditable="true" onblur={(e) => handleEdit(book, 'authors', e)} onkeydown={handleEnter}
-    >{book.authors?.join(', ') || ''}</td
-  >
-  <td
-    contenteditable="true"
-    onblur={(e) => updateTags(book, e.currentTarget.innerHTML)}
-    onkeydown={handleEnter}>{book.tags?.map((bookTag) => bookTag.name).join(', ') || ''}</td
-  >
+  <EditableTd
+    value={book.isbn10}
+    onChange={(newValue: string) => handleEdit(book, 'isbn10', newValue)}
+  />
+  <EditableTd
+    value={book.isbn13}
+    onChange={(newValue: string) => handleEdit(book, 'isbn13', newValue)}
+  />
+  <EditableTd
+    value={book.title}
+    onChange={(newValue: string) => handleEdit(book, 'title', newValue)}
+  />
+  <EditableTd
+    value={book.authors?.join(', ')}
+    onChange={(newValue: string) => handleEdit(book, 'authors', newValue)}
+  />
+  <EditableTd
+    value={book.tags.map((bookTag) => bookTag.name).join(', ')}
+    onChange={(newValue: string) => updateTags(book, newValue)}
+  />
   <td>
     <label class="b-checkbox checkbox is-regular m-1">
       <input

--- a/src-ui/lib/components/core/EditableTd.svelte
+++ b/src-ui/lib/components/core/EditableTd.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  interface Props {
+    /**
+     * Value that can be edited in this table.
+     */
+    value: string | null
+
+    /**
+     * Function for handling value changes.
+     */
+    onChange: (newVal: string) => void
+  }
+
+  let { value, onChange }: Props = $props()
+
+  let currVal = $state(value)
+
+  function handleBlur() {
+    onChange(currVal || '')
+  }
+
+  function handleEnter(event: Event) {
+    if (event instanceof KeyboardEvent && event.key === 'Enter') {
+      event.preventDefault?.()
+      ;(event.currentTarget as HTMLTableCellElement).blur?.()
+    }
+  }
+</script>
+
+<td contenteditable onblur={handleBlur} onkeydown={handleEnter} bind:innerText={currVal}></td>


### PR DESCRIPTION
There was a bug that visually "doubled" the data in a field when editing it. Subsequent edits would include the extra "doubled" data. This is because Svelte doesn't play nice with manually rendered content in a field that is then changed by non-Svelte (content editable).

Svelte does have a good workaround for this: you can `bind:` `innerHTML` or `innerText`, and work with the resulting reactive value. Since we don't want to update the DB on every key press, we have wrapped up the `bind:innerText` behavior into a component that takes an `onChange` function parameter, which it calls when the field is blurred (or `Enter` is pressed)